### PR TITLE
Removes the static keyword from classFromType and getPropertyInfo

### DIFF
--- a/MYDynamicObject.h
+++ b/MYDynamicObject.h
@@ -48,10 +48,21 @@
 
 @end
 
-Class classFromType(const char* propertyType);
+/** Given an Objective-C class object, a property name, and a BOOL for whether the property should be readwrite,
+    return YES if a property with the name exists , NO otherwise.
+    If setter argument is YES but property is declared readonly, also returns NO.
+    Information about the property is returned by reference: the subclass of cls that declares the property, 
+    and the property string part of the property attributes string.
+ */
+BOOL MYGetPropertyInfo(Class cls,
+                       NSString *propertyName,
+                       BOOL setter,
+                       Class *declaredInClass,
+                       const char* *propertyType);
 
-BOOL getPropertyInfo(Class cls,
-                     NSString *propertyName,
-                     BOOL setter,
-                     Class *declaredInClass,
-                     const char* *propertyType);
+
+/** Given an Objective-C property type string, returns the property type as a Class object, 
+    or nil if a class does not apply or no such property is present.
+    See Property Type String section of the Objective-C Runtime Programming Guide 
+    for more information about the format of the string. */
+Class MYClassFromType(const char* propertyType);


### PR DESCRIPTION
This is so that these functions can be accessed in MYDynamicObject subclasses which need to do some more class / property reasoning. Hope this is OK? Would you prefer these function names to be made a bit more unique to avoid clashing with something unrelated?
