### PR TITLE
Fixed ExceptionUtils using deprecated Logging.h and missing include pthread.h

### DIFF
--- a/ExceptionUtils.m
+++ b/ExceptionUtils.m
@@ -12,6 +12,7 @@
 #import "MYLogging.h"
 #import "Test.h"
 
+#include <pthread.h>
 
 #if !__has_feature(objc_arc)
 #error This source file must be compiled with ARC

--- a/ExceptionUtils.m
+++ b/ExceptionUtils.m
@@ -9,7 +9,7 @@
 
 #import "ExceptionUtils.h"
 
-#import "Logging.h"
+#import "MYLogging.h"
 #import "Test.h"
 
 


### PR DESCRIPTION
* Imported MYLogging.h instead of Logging.h.
* Added #include <pthread.h>