### PR TITLE
Fix disabling background monitor feature for App Extension

### DIFF
--- a/MYBackgroundMonitor.h
+++ b/MYBackgroundMonitor.h
@@ -37,15 +37,15 @@
     The app will soon stop being scheduled for CPU time unless the block starts a background task
     by calling -beginBackgroundTaskNamed:. 
     NOTE: Called on the main thread. */
-@property (atomic, strong) void (^onAppBackgrounding)();
+@property (atomic, strong) void (^onAppBackgrounding)(void);
 
 /** Called when the app returns to the foreground.
     NOTE: Called on the main thread. */
-@property (atomic, strong) void (^onAppForegrounding)();
+@property (atomic, strong) void (^onAppForegrounding)(void);
 
 /** Called if the OS loses its patience before -endBackgroundTask is called.
     The task is implicitly ended, and the app will soon stop being scheduled for CPU time.
     NOTE: Called on the main thread. */
-@property (atomic, strong) void (^onBackgroundTaskExpired)();
+@property (atomic, strong) void (^onBackgroundTaskExpired)(void);
 
 @end

--- a/MYBackgroundMonitor.m
+++ b/MYBackgroundMonitor.m
@@ -22,6 +22,16 @@
 @synthesize onBackgroundTaskExpired=_onBackgroundTaskExpired;
 
 
+static BOOL runningInAppExtension() {
+    return [[[[NSBundle mainBundle] bundlePath] pathExtension] isEqualToString: @"appex"];
+}
+
+
+static UIApplication* sharedApplication() {
+    return [[UIApplication class] performSelector: @selector(sharedApplication)];
+}
+
+
 - (instancetype) init {
     self = [super init];
     if (self) {
@@ -32,7 +42,9 @@
 
 
 - (void) start {
-#if NS_EXTENSION_UNAVAILABLE_IOS
+    if (runningInAppExtension())
+        return;
+    
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(appBackgrounding:)
                                                  name: UIApplicationDidEnterBackgroundNotification
@@ -46,15 +58,15 @@
         if (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground)
             [self appBackgrounding: nil];
     });
-#endif
 }
 
 
 - (void) stop {
-#if NS_EXTENSION_UNAVAILABLE_IOS
+    if (runningInAppExtension())
+        return;
+    
     [[NSNotificationCenter defaultCenter] removeObserver: self];
     [self endBackgroundTask];
-#endif
 }
 
 
@@ -64,7 +76,9 @@
 
 
 - (BOOL) endBackgroundTask {
-#if NS_EXTENSION_UNAVAILABLE_IOS
+    if (runningInAppExtension())
+        return NO;
+    
     @synchronized(self) {
         if (_bgTask == UIBackgroundTaskInvalid)
             return NO;
@@ -72,14 +86,13 @@
         _bgTask = UIBackgroundTaskInvalid;
         return YES;
     }
-#else
-    return NO;
-#endif
 }
 
 
 - (BOOL) beginBackgroundTaskNamed: (NSString*)name {
-#if NS_EXTENSION_UNAVAILABLE_IOS
+    if (runningInAppExtension())
+        return NO;
+    
     @synchronized(self) {
         if (_bgTask == UIBackgroundTaskInvalid) {
             _bgTask = [[UIApplication sharedApplication] beginBackgroundTaskWithName: name
@@ -95,9 +108,6 @@
         }
         return (_bgTask != UIBackgroundTaskInvalid);
     }
-#else
-    return NO;
-#endif
 }
 
 

--- a/MYBackgroundMonitor.m
+++ b/MYBackgroundMonitor.m
@@ -55,7 +55,7 @@ static UIApplication* sharedApplication() {
                                                object: nil];
     // Already in the background? Better start a background session now:
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground)
+        if (sharedApplication().applicationState == UIApplicationStateBackground)
             [self appBackgrounding: nil];
     });
 }
@@ -82,7 +82,7 @@ static UIApplication* sharedApplication() {
     @synchronized(self) {
         if (_bgTask == UIBackgroundTaskInvalid)
             return NO;
-        [[UIApplication sharedApplication] endBackgroundTask: _bgTask];
+        [sharedApplication() endBackgroundTask: _bgTask];
         _bgTask = UIBackgroundTaskInvalid;
         return YES;
     }
@@ -95,8 +95,8 @@ static UIApplication* sharedApplication() {
     
     @synchronized(self) {
         if (_bgTask == UIBackgroundTaskInvalid) {
-            _bgTask = [[UIApplication sharedApplication] beginBackgroundTaskWithName: name
-                                                                   expirationHandler: ^{
+            _bgTask = [sharedApplication() beginBackgroundTaskWithName: name
+                                                     expirationHandler: ^{
                 // Process ran out of background time before endBackgroundTask was called.
                 // NOTE: Called on the main thread
                 if (_bgTask != UIBackgroundTaskInvalid) {


### PR DESCRIPTION
* NS_EXTENSION_UNAVAILABLE_IOS is for marking that the method is not available for App Entension, not for branching the code.

* Instead of using NS_EXTENSION_UNAVAILABLE_IOS, explicitly check if the code is run in the App Extension or not. I have seen the React Native library using this technique for checking if the app extension is running or not.

* Access shared application by using performSelector so the code can also be used with the App Extension target.