### PR TITLE
Fixed: Build failed due to the new Xcode 9.3 compiler warning

### DIFF
--- a/MYErrorUtils.m
+++ b/MYErrorUtils.m
@@ -261,8 +261,8 @@ NSError* MYMapError(NSError* error, NSDictionary* map) {
 
 - (NSString*) my_compactDescription {
     NSDictionary* userInfo = self.userInfo;
-    NSMutableString* s = [NSMutableString stringWithFormat: @"%@[%zd",
-                          MYShortErrorDomainName(self.domain), self.code];
+    NSMutableString* s = [NSMutableString stringWithFormat: @"%@[%ld",
+                          MYShortErrorDomainName(self.domain), (long)self.code];
     NSString* desc = self.my_nonDefaultLocalizedDescription;
     if (desc)
         [s appendFormat: @", \"%@\"", desc];


### PR DESCRIPTION
Casting an NSInteger argument for String Format to long as suggested in https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html