### PR TITLE
Add accessible to MYGetOrCreateAnonymousIdentity and replace assertion check with warning in MYFindIdentity 

### DIFF
--- a/MYAnonymousIdentity.h
+++ b/MYAnonymousIdentity.h
@@ -17,10 +17,16 @@
     @param label  A string identifying the purpose of this identity.
     @param expirationInterval  The amount of time the certificate should remain valid.
             Typically a year.
+    @param accessible   A kSecAttrAccessible's value indicating when a keychain item is accessible.
+            If a NULL value is passed, the kSecAttrAccessible key will not be set to the attributes of
+            keys and the certificate when saving them in the keychain; as a result, the default
+            kSecAttrAccessible’s value which is kSecAttrAccessibleWhenUnlocked will be automatically
+            applied by the OS.
     @return  An autoreleased identity reference that can be used when configuring a socket for SSL
             using the CFStream or SecureTransport APIs. */
 SecIdentityRef MYGetOrCreateAnonymousIdentity(NSString* label,
                                               NSTimeInterval expirationInterval,
+                                              CFStringRef accessible,
                                               NSError** outError);
 
 /** Finds an identity (anonymous or not) in the keychain with the given label. */

--- a/MYAnonymousIdentity.m
+++ b/MYAnonymousIdentity.m
@@ -294,7 +294,8 @@ SecIdentityRef MYFindIdentity(NSString* label) {
     CFTypeRef ref = NULL;
     OSStatus err = SecItemCopyMatching((__bridge CFDictionaryRef)query, &ref);
     if (err) {
-        AssertEq(err, errSecItemNotFound); // other err indicates query dict is malformed
+        if (err != errSecItemNotFound)
+            Warn(@"Unexpected error %d found when retrieving SSL identity labeled \"%@\"", (int)err, label);
         return NULL;
     }
     return (SecIdentityRef)ref;


### PR DESCRIPTION
* Added accessible param whose value indicates when a keychain item is accessible. If passing a NULL value, the kSecAttrAccessible key will not be set to the keys/certificates when saving them in the keychain; as a result, the default kSecAttrAccessible’s value from the OS which is kSecAttrAccessibleWhenUnlocked will be automatically applied.

* Instead of using assert, warning when an error beside errSecItemNotFound such as errSecInteractionNotAllowed (-25308)occurs to avoid abort and crash.